### PR TITLE
Add MagicCosmetics material documentation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings" defaultProject="true" />
+</project>

--- a/configurations/items.md
+++ b/configurations/items.md
@@ -15,6 +15,7 @@ The material of the item. You can use a placeholder to display a material.
 > * [Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) - Example: `material: STONE`
 > * [Placeholder](https://www.spigotmc.org/resources/placeholderapi.6245/) value - Example: `material: %your_placeholder_material%`
 > * FREE - [zHead](https://www.spigotmc.org/resources/zhead-database.115717/) **RECOMMENDED** (zhd:\<id>) Example: `material: "zhd:<id>"`
+> * FREE - [MagicCosmetics](https://polymart.org/resource/magic-cosmetics-20-off.2070) (magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>) Example: `material: "magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>"`
 > * PAID - zItems (ztems:\<item name>) Example: `material: "zitems:<id>"`
 > * PAID - [HeadDatabase](https://www.spigotmc.org/resources/head-database.14280/) (hdb:\<id>) Example: `material: "hdb:<id>"`
 > * PAID - [Oraxen](https://www.spigotmc.org/resources/%E2%98%84%EF%B8%8F-oraxen-add-items-blocks-armors-hats-food-furnitures-plants-and-gui-1-18-1-20-1.72448/) (oraxen:\<item name>) Example: `material: "oraxen:<item name>"`

--- a/configurations/items.md
+++ b/configurations/items.md
@@ -15,7 +15,7 @@ The material of the item. You can use a placeholder to display a material.
 > * [Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) - Example: `material: STONE`
 > * [Placeholder](https://www.spigotmc.org/resources/placeholderapi.6245/) value - Example: `material: %your_placeholder_material%`
 > * FREE - [zHead](https://www.spigotmc.org/resources/zhead-database.115717/) **RECOMMENDED** (zhd:\<id>) Example: `material: "zhd:<id>"`
-> * FREE - [MagicCosmetics](https://polymart.org/resource/magic-cosmetics-20-off.2070) (magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>) Example: `material: "magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>"`
+> * PAID - [MagicCosmetics](https://polymart.org/resource/magic-cosmetics-20-off.2070) (magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>) Example: `material: "magic_cosmetics:<HAT/HAT/BAG/WALKING_STICK/BALLOON/SPRAY>"`
 > * PAID - zItems (ztems:\<item name>) Example: `material: "zitems:<id>"`
 > * PAID - [HeadDatabase](https://www.spigotmc.org/resources/head-database.14280/) (hdb:\<id>) Example: `material: "hdb:<id>"`
 > * PAID - [Oraxen](https://www.spigotmc.org/resources/%E2%98%84%EF%B8%8F-oraxen-add-items-blocks-armors-hats-food-furnitures-plants-and-gui-1-18-1-20-1.72448/) (oraxen:\<item name>) Example: `material: "oraxen:<item name>"`


### PR DESCRIPTION
Add MagicCosmetics material loader documentation in items page.

Changes:
- Added MagicCosmetics plugin support in the material format list
- Added usage example for MagicCosmetics material loader
- Added link to MagicCosmetics plugin resource