### PR TITLE
docs(items): Add tipped arrow

### DIFF
--- a/configurations/items.md
+++ b/configurations/items.md
@@ -128,7 +128,8 @@ Defines how the lore is used.\
   potion: <potion effect type>
   level: <potion level, 1 or 2> # 1 by default
   splash: <potion splash true or false>
-  extended: <potion extended true of flase>
+  extended: <potion extended true or false>
+  arrow: <true or false> # potion will be a Tipped Arrow
 ```
 
 Allows you to create a potion. Check potion effect types [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionType.html) for more details.


### PR DESCRIPTION
This pull request includes a small correction to the `configurations/items.md` file and adds a new feature for potion configuration.

Key changes:

* Corrected a typo in the `extended` property description, changing "flase" to "false".
* Added an `arrow` property to specify whether the potion will be a Tipped Arrow (`true` or `false`).